### PR TITLE
Revamp hooks for nodeChange

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -44,15 +44,13 @@ export const isVisible = (item, snapshot) =>
  */
 
 /**
- * @typedef {function(Y.Doc, PModel.Node | PModel.Node[], number=): void} AddRemoveHookCb
- * @typedef {function(Y.Doc, (PModel.Node | PModel.Node[])[]): void} ReorderHookCb
+ * @typedef {function(Y.Doc, (PModel.Node | PModel.Node[])[]): void} HookCb
  */
 
 /**
  * @typedef {{
- * onInsertNode?: AddRemoveHookCb,
- * onRemoveNode?: AddRemoveHookCb,
- * onOrderChange?: ReorderHookCb
+ * onPageChange?: HookCb
+ * onOrderChange?: HookCb
  * }} Hooks
  */
 
@@ -234,10 +232,8 @@ export const ySyncPlugin = (yXmlFragment, {
                 // Running this here since we need it to be a part of the
                 // same transaction as the changes in XmlFragment
                 if (pluginState.orderChange) {
-                  const { nodeType, newOrder } = pluginState.orderChange;
-                  const yNodes = Array.from(pluginState.type.createTreeWalker(yxml => yxml.nodeName === nodeType));
+                  const yNodes = Array.from(pluginState.type.createTreeWalker(yxml => yxml.nodeName === 'page'));
                   const pNodes = yNodes.map((yNode) => binding.mapping.get(yNode));
-                  console.debug({ newOrder, orderFromFragment: pNodes });
                   hooks?.onOrderChange?.(pluginState.doc, pNodes);
                 }
               }, ySyncPluginKey)
@@ -1012,6 +1008,8 @@ const marksToAttributes = (marks) => {
  * @param {Hooks} [hooks]
  */
 export const updateYFragment = (y, yDomFragment, pNode, mapping, hooks) => {
+  let hasChange = false;
+
   if (
     yDomFragment instanceof Y.XmlElement &&
     yDomFragment.nodeName !== pNode.type.name
@@ -1159,18 +1157,23 @@ export const updateYFragment = (y, yDomFragment, pNode, mapping, hooks) => {
       yChildren[0].delete(0, yChildren[0].length)
     } else if (yDelLen > 0) {
       yDomFragment.slice(left, left + yDelLen).forEach(type => {
-        hooks?.onRemoveNode?.(y, mapping.get(type), left);
         mapping.delete(type)
       })
       yDomFragment.delete(left, yDelLen)
+      hasChange = true
     }
     if (left + right < pChildCnt) {
       const ins = []
       for (let i = left; i < pChildCnt - right; i++) {
         ins.push(createTypeFromTextOrElementNode(pChildren[i], mapping))
-        hooks?.onInsertNode?.(y, pChildren[i], i);
       }
       yDomFragment.insert(left, ins)
+      hasChange = true
+    }
+    if (hasChange) {
+      const yNodes = Array.from(yDomFragment.createTreeWalker((yxml) => yxml.nodeName === 'page'));
+      const pNodes = yNodes.map((yNode) => mapping.get(yNode));
+      hooks?.onPageChange(y, pNodes);
     }
   }, ySyncPluginKey)
 }


### PR DESCRIPTION
The `sync-plugin` doesn't care about preserving nodes for example:


line 1
li[ **ne 2
line 3** ]

and 

line 1
[ **line 2
lin** ]e 3

Consider the above two remove operations on the same set of nodes (text between [ ] is removed). Both these operations cause the 3rd node (line 3) to be removed. The 2nd node is then updated with the remaining text and the correct `internal_id`.

Because of this it is not possible to keep the current `onRemoveNode` implementation. The straightforward way to do this instead is to compare both the current and new nodes and sync the diffs. To enable this I've added an `onPageChange` hook that sends the current page nodes when an insert/delete happens. 